### PR TITLE
Return RPC listening address

### DIFF
--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -529,8 +529,12 @@ where
 		)
 	};
 
-	let rpc = start_rpc_servers(&config, gen_rpc_module, rpc_id_provider)?;
-	let rpc_handlers = RpcHandlers(Arc::new(gen_rpc_module(sc_rpc::DenyUnsafe::No)?.into()));
+	let (rpc, socket_addr) = start_rpc_servers(&config, gen_rpc_module, rpc_id_provider)?;
+
+	let rpc_handlers = RpcHandlers {
+		rpc_module: Arc::new(gen_rpc_module(sc_rpc::DenyUnsafe::No)?.into()),
+		listen_addresses: Box::new([socket_addr.ip().into()]),
+	};
 
 	// Spawn informant task
 	spawn_handle.spawn(

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -33,6 +33,7 @@ pub mod client;
 mod client;
 mod metrics;
 mod task_manager;
+use crate::config::Multiaddr;
 
 use std::{collections::HashMap, net::SocketAddr};
 
@@ -45,6 +46,7 @@ use sc_network::{
 	config::MultiaddrWithPeerId, NetworkBlock, NetworkPeers, NetworkStateInfo, PeerId,
 };
 use sc_network_sync::SyncingService;
+use sc_rpc_server::ServerAndListenAddress;
 use sc_utils::mpsc::TracingUnboundedReceiver;
 use sp_blockchain::HeaderMetadata;
 use sp_consensus::SyncOracle;
@@ -96,7 +98,10 @@ const DEFAULT_PROTOCOL_ID: &str = "sup";
 
 /// RPC handlers that can perform RPC queries.
 #[derive(Clone)]
-pub struct RpcHandlers(Arc<RpcModule<()>>);
+pub struct RpcHandlers {
+	rpc_module: Arc<RpcModule<()>>,
+	listen_addresses: Box<[Multiaddr]>,
+}
 
 impl RpcHandlers {
 	/// Starts an RPC query.
@@ -112,7 +117,7 @@ impl RpcHandlers {
 		&self,
 		json_query: &str,
 	) -> Result<(String, mpsc::UnboundedReceiver<String>), JsonRpseeError> {
-		self.0
+		self.rpc_module
 			.raw_json_request(json_query)
 			.await
 			.map(|(method_res, recv)| (method_res.result, recv))
@@ -120,7 +125,12 @@ impl RpcHandlers {
 
 	/// Provides access to the underlying `RpcModule`
 	pub fn handle(&self) -> Arc<RpcModule<()>> {
-		self.0.clone()
+		self.rpc_module.clone()
+	}
+
+	/// Provides access to listen addresses
+	pub fn listen_addresses(&self) -> &[Multiaddr] {
+		&self.listen_addresses[..]
 	}
 }
 
@@ -368,7 +378,7 @@ fn start_rpc_servers<R>(
 	config: &Configuration,
 	gen_rpc_module: R,
 	rpc_id_provider: Option<Box<dyn RpcSubscriptionIdProvider>>,
-) -> Result<Box<dyn std::any::Any + Send + Sync>, error::Error>
+) -> Result<(Box<dyn std::any::Any + Send + Sync>, SocketAddr), error::Error>
 where
 	R: Fn(sc_rpc::DenyUnsafe) -> Result<RpcModule<()>, Error>,
 {
@@ -408,9 +418,13 @@ where
 	// `block_in_place` is a hack to allow callers to call `block_on` prior to
 	// calling `start_rpc_servers`.
 	match tokio::task::block_in_place(|| {
-		config.tokio_handle.block_on(sc_rpc_server::start_server(server_config))
+		config
+			.tokio_handle
+			.block_on(sc_rpc_server::start_server_and_get_listen_address(server_config))
 	}) {
-		Ok(server) => Ok(Box::new(waiting::Server(Some(server)))),
+		Ok(ServerAndListenAddress { handle, listen_addr }) => {
+			Ok((Box::new(waiting::Server(Some(handle))), listen_addr))
+		},
 		Err(e) => Err(Error::Application(e)),
 	}
 }


### PR DESCRIPTION
# Description

*Please include a summary of the changes and the related issue. Please also include relevant motivation and context, including:*

- What does this PR do?
- Why are these changes needed?
- How were these changes implemented and what do they affect?

This PR allows the RPC server's socket address to be returned when initializing the server. This was done by introducing a new version of the sc_service::spawn_tasks function called sc_service::spawn_tasks_and_get_socket_addr. The old function was left in place for backwards compatibility since it is a public function exposed by the library.

This allows the library consumer to easily determine which port the RPC server is listening on. My use case for this is automated testing. I'd like to be able to simply specify that the server bind to port '0' and then test against whatever port the OS assigns dynamically.

A side effect of this change is that if the port binding completely fails ([including the fall back to port 0](https://github.com/gensyn-ai/substrate/blob/d7a122f/client/service/src/lib.rs#L383-L387)), then the initialization of the RPC server will fail with an Error. Previously, the server would start without any listening address. I believe it is better to fail loudly and make the problem more obvious in this rare edge case, which is why I decided to write the code this way.

